### PR TITLE
Changed section to correct level

### DIFF
--- a/src/main/java/de/braintags/io/vertx/util/package-info.java
+++ b/src/main/java/de/braintags/io/vertx/util/package-info.java
@@ -11,7 +11,7 @@
  * = vertx-util
  * utilities and helper for vertx-based programming
  * 
- * === Using vertx-util
+ * == Using vertx-util
  * To use this project, add the following dependency to the _dependencies_ section of your build descriptor:
  * 
  * * Maven (in your `pom.xml`):


### PR DESCRIPTION
During asciidoctor convertion the follwing warning is shown 4 times, one pre langue :
`asciidoctor: WARNING: index.adoc: line 8: section title out of sequence: expected levels 0 or 1, got level 2`
This gets rid of the warning by changing the section level to the correct level